### PR TITLE
Fix Deposits amount for transfers

### DIFF
--- a/addon/pnl/src/api.ts
+++ b/addon/pnl/src/api.ts
@@ -108,10 +108,7 @@ export const parseTransactionsResponse = (response: any, currencyCache: any, acc
       if (['deposit'].includes(type)) {
         portfolioData.deposit += amount;
       } else if (type === 'transfer') {
-        // Ignore security transfers...
-        if (!transaction.symbol) {
           portfolioData.deposit += amount;
-        }
       } else if (['fee', 'interest', 'tax'].includes(type)) {
         portfolioData.interest += Math.abs(amount);
       } else if (['income', 'dividend', 'distribution'].includes(type)) {


### PR DESCRIPTION
Following up on issue #4  I noticed that the code change made did not fix it.
I was checking the code, and I see that there is a check if a transaction has a symbol. In my case, the transaction has a symbol, because I am transferring a position from one account to another.

For example:
Imagine that at this moment, Short therm Account has total deposits amount of 1000 and Long therm Account has total deposits amount of 2000.
Then, we transfer some positions from Short therm to Long therm, generating these two transactions:

Account: Short therm
Type: Transfer
Symbol: GLDM
Amount: -100
Quantity: -2.5

Account: Long therm
Type: Transfer
Symbol: GLDM
Amount: 100
Quantity: 2.5

The expected final result should be:
Short therm Account has total deposits amount of 900 and Long therm Account has total deposits amount of 2100.

Does this change make sense? We can discuss further to clarify.

PS: I do not know what Ignore security transfer means and why it is important, perhaps you can clarify me.